### PR TITLE
Move optional dependencies to `run_constrained` requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,22 @@
 # Everything else is managed by the conda-smithy rerender process.
 # Please do not modify
 
+# Ignore all files and folders in root
 *
 !/conda-forge.yml
 
-!/*/
+# Don't ignore any files/folders if the parent folder is 'un-ignored'
+# This also avoids warnings when adding an already-checked file with an ignored parent.
+!/**/
+# Don't ignore any files/folders recursively in the following folders
 !/recipe/**
 !/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
 
 *.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -54,12 +54,6 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
-if [[ "${sha:-}" == "" ]]; then
-  pushd ${FEEDSTOCK_ROOT}
-  sha=$(git rev-parse HEAD)
-  popd
-fi
-
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,6 @@ requirements:
     - toml >=0.10.2,<1.0.0
     - xlrd >=2.0.0,<3.0.0
     - xmltodict >=0.12.0,<1.0.0
-    
 test:
   imports:
     - benedict

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - python-slugify >=7.0.0,<9.0.0
     - requests >=2.26.0,<3.0.0
   run_constrained:
-    - beautifulsoup4 >= 4.12.0, < 5.0.0
+    - beautifulsoup4 >=4.12.0,<5.0.0
     - boto3 >=1.24.89,<2.0.0
     - ftfy >=6.0.0,<7.0.0
     - mailchecker >=4.1.0,<7.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: e65ecfc16b505b0fefa08ed97c65f6f93cf32c0309dd2e1614fc0f58f22b2c4e
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -20,21 +20,23 @@ requirements:
     - pip
     - python >=3.4
   run:
-    - boto3 >=1.24.89,<2.0.0
-    - ftfy >=6.0.0,<7.0.0
-    - mailchecker >=4.1.0,<6.0.0
-    - openpyxl >=3.0.0,<4.0.0
-    - phonenumbers >=8.12.0,<9.0.0
     - python >=3.6
-    - python-dateutil >=2.8.0,<3.0.0
     - python-fsutil >=0.9.3,<1.0.0
     - python-slugify >=7.0.0,<9.0.0
-    - pyyaml >=6.0,<7.0
     - requests >=2.26.0,<3.0.0
+  run_constrained:
+    - beautifulsoup4 >= 4.12.0, < 5.0.0
+    - boto3 >=1.24.89,<2.0.0
+    - ftfy >=6.0.0,<7.0.0
+    - mailchecker >=4.1.0,<7.0.0
+    - openpyxl >=3.0.0,<4.0.0
+    - phonenumbers >=8.12.0,<9.0.0
+    - python-dateutil >=2.8.0,<3.0.0
+    - pyyaml >=6.0,<7.0
     - toml >=0.10.2,<1.0.0
     - xlrd >=2.0.0,<3.0.0
     - xmltodict >=0.12.0,<1.0.0
-
+    
 test:
   imports:
     - benedict


### PR DESCRIPTION
Fixes #35 

Dependencies and their pinning has been updated to match the pinning in the `pyproject.toml` for the v0.33.1 tag in the main repo: https://github.com/fabiocaccamo/python-benedict/blob/0.33.1/pyproject.toml

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
